### PR TITLE
Refactor noted & initial todo.txt support

### DIFF
--- a/include/note.hpp
+++ b/include/note.hpp
@@ -27,8 +27,8 @@ private:
 public:
     bool completed = false;
     char priority = 'z';
-    tm * createdAt;
-    tm * completedAt;
+    tm * createdAt = nullptr;
+    tm * completedAt = nullptr;
     std::string description;
     
     std::string toString();
@@ -62,7 +62,7 @@ public:
     void del(std::vector<int> numbers);
     void list(bool show_completed);
     void show(int n);
-
+    void complete(int n);
     
     std::vector<todoTxtNote> getList();
 };

--- a/include/note.hpp
+++ b/include/note.hpp
@@ -20,6 +20,26 @@
 #define XDG_CONFIG_HOME std::getenv("XDG_CONFIG_HOME")
 #define XDG_DATA_HOME std::getenv("XDG_DATA_HOME")
 
+class todoTxtNote {
+private:
+    static tm * parseTime(std::string s, const char* format);
+    std::vector<std::string> words;
+public:
+    bool completed = false;
+    char priority = 'z';
+    tm * createdAt;
+    tm * completedAt;
+    std::string description;
+    
+    std::string toString();
+    
+    std::vector<std::vector<tm>> getNotificationSpecs();
+    std::vector<std::string> getProjects(), getContexts();
+    
+    todoTxtNote(std::string raw);
+    ~todoTxtNote();
+};
+
 class Note {
 private:
     // Filestreams
@@ -40,7 +60,9 @@ public:
     
     void add(char* note);
     void del(std::vector<int> numbers);
-    void list();
+    void list(bool show_completed);
     void show(int n);
-    std::vector<std::string> getList();
+
+    
+    std::vector<todoTxtNote> getList();
 };

--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/5ahm89gn7xsfdgfbqdsg8w243phgdwli-termNote

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,9 @@ static int parseOptions(int key, char *arg,
         case 's':
             note->show(std::strtol(arg, nullptr, 0));
             break;
+        case 'c':
+            note->complete(std::strtol(arg, nullptr, 0));
+            break;
         case 'd':
             std::vector<int> numbers;
             std::stringstream ss(arg);
@@ -48,6 +51,7 @@ int main(int argc, char **argv) {
         {"show-completed", 'x', 0, 0, "Show entries that are marked as completed while listing"},
         {"list", 'l', 0, 0, "List all entries"},
         {"show", 's', "int", 0, "Show [n]th entry"},
+        {"complete", 'c', "int", 0, "Mark [n]th entry as completed"},
         { 0 }
         };
         struct argp argp = { options, parseOptions };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,11 +3,16 @@
 
 std::unique_ptr<Note> note = std::make_unique<Note>();
 
+bool show_completed = false;
+
 static int parseOptions(int key, char *arg,
                         struct argp_state *state) {
     switch(key) {
+        case 'x':
+            show_completed = true;
+            break;
         case 'l':
-            note->list();
+            note->list(show_completed);
             break;
         case 'a':
             note->add(arg);
@@ -33,13 +38,14 @@ static int parseOptions(int key, char *arg,
 
 int main(int argc, char **argv) {
     if(argc == 1) {
-        note->list();
+        note->list(false);
     }
     else {
         struct argp_option options[] = {
         {"add", 'a', "string", 0, "Add an entry"},
         {"delete", 'd', "int", 0, "Delete [n]th entry"},
         {"delete", 'd', "list", 0, "Delete [n]th entries"},
+        {"show-completed", 'x', 0, 0, "Show entries that are marked as completed while listing"},
         {"list", 'l', 0, 0, "List all entries"},
         {"show", 's', "int", 0, "Show [n]th entry"},
         { 0 }

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -80,6 +80,26 @@ todoTxtNote::todoTxtNote(std::string raw) {
         description += words[i] + ' ';
 }
 
+std::string todoTxtNote::toString() {
+    std::string result;
+    if (completed) result += "x ";
+    result += "(";
+    result += priority;
+    result += ")";
+    if (completedAt) {
+        std::ostringstream ss;
+        ss << std::put_time(completedAt, "%Y-%m-%d");
+        result += ' ' + ss.str();
+    }
+    if (createdAt) {
+        std::ostringstream ss;
+        ss << std::put_time(createdAt, "%Y-%m-%d");
+        result += ' ' + ss.str();
+    }
+    result += " " + description;
+    return result;
+}
+
 todoTxtNote::~todoTxtNote() {
 
 }
@@ -103,8 +123,10 @@ Note::~Note() {
 }
 
 void Note::add(char* note) {
-    this->noteStream.open(this->file, std::ios::app);
-    noteStream << note << std::endl;
+    noteStream.open(this->file, std::ios::app);
+    todoTxtNote parsedNote(note);
+    noteStream << parsedNote.toString() << std::endl;
+    noteStream.close();
 }
 
 void Note::del(std::vector<int> numbers) {
@@ -157,4 +179,22 @@ void Note::list(bool show_completed) {
 
 void Note::show(int n) {
     std::cout << getList()[n].description << std::endl;
+}
+
+
+void Note::complete(int n) {
+    std::vector<todoTxtNote> notes = getList();
+    if (notes[n].completed) {
+        notes[n].completed = false;
+        notes[n].completedAt = nullptr;
+    } else {
+        notes[n].completed = true;
+        time_t now = std::time(0);
+        notes[n].completedAt = localtime(&now);
+    }
+    tempStream.open(tempFile, std::ios::out);
+    for (auto note: notes) tempStream << note.toString() << std::endl;
+    tempStream.close();
+    remove(file.c_str());
+    rename(tempFile.c_str(), file.c_str());
 }

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -1,5 +1,88 @@
 #include <algorithm>
+#include <iterator>
+
+#include <chrono>
+#include <ctime>
+#include <iomanip>
 #include "../include/note.hpp"
+
+tm * todoTxtNote::parseTime(std::string s, const char *format) {
+    std::istringstream buf(s);
+    struct tm * unit = (struct tm*) malloc(sizeof(struct tm));
+    unit->tm_year = -1;
+    unit->tm_mon = -1;
+    unit->tm_mday = -1;
+    unit->tm_wday = -1;
+    unit->tm_hour = -1;
+    unit->tm_min = -1;
+    unit->tm_sec = -1;
+    buf >> std::get_time(unit, format);
+    if (!buf.fail()) return unit;
+    else return nullptr;
+}
+
+std::vector< std::vector<tm> > todoTxtNote::getNotificationSpecs() {
+    int i = 0;
+    std::vector<std::vector<struct tm>> specs;
+    std::vector<tm> spec;
+    for (auto & w: words) {
+        tm * cur;
+        if ((cur = parseTime(w, "%R")) ||
+            (cur = parseTime(w, "%H%p")) ||
+            (cur = parseTime(w, "%d.%m.%y")) ||
+            (cur = parseTime(w, "%d.%m")) ||
+            (cur = parseTime(w, "%a")) ||
+            (cur = parseTime(w, "%b"))) {
+            spec.push_back(*cur);
+        }
+        std::string sep = ",./;!%&";
+        if (!cur || sep.find(w[w.size() - 1]) != std::string::npos) {
+            if (spec.size() > 0)
+                specs.push_back(spec);
+            spec.clear();
+        }
+    }
+    if (spec.size() > 0) specs.push_back(spec);
+    return specs;
+}
+
+todoTxtNote::todoTxtNote(std::string raw) {
+    std::istringstream rawstream(raw);
+    words = std::vector<std::string>{std::istream_iterator<std::string>{rawstream},
+                                     std::istream_iterator<std::string>{}};
+    while (words.size() < 5) words.push_back("");
+    short i = 0;
+    if (words[i] == "x") {
+        completed = true;
+        i ++;
+    }
+    if (words[i].size() == 3 && words[i][0] == '(' && words[i][2] == ')') {
+        priority = words[i][1];
+        i ++;
+    }
+
+    tm * time1 = parseTime(words[i], "%Y-%m-%d");
+    tm * time2 = parseTime(words[i + 1], "%Y-%m-%d");
+    
+    if (time1 && time2) {
+        completedAt = time1;
+        createdAt = time2;
+        i += 2;
+    } else if (time1) {
+        createdAt = time1;
+        i ++;
+    } else {
+        time_t now = std::time(0);
+        createdAt = localtime(&now);
+    }
+
+    for (i; i < words.size(); i ++)
+        description += words[i] + ' ';
+}
+
+todoTxtNote::~todoTxtNote() {
+
+}
 
 Note::Note() {
     // Look if termNote directories and files exist, if not then create them
@@ -53,34 +136,25 @@ void Note::del(std::vector<int> numbers) {
         exit(1);
     }
 }
-
-void Note::list() {
+std::vector<todoTxtNote> Note::getList() {
     noteStream.open(file, std::ios::in);
-    int i = 0;
-    while(std::getline(noteStream, line)) {
-        std::string newLine;
-        newLine = line + "\n";
-        std::cout <<"[" << i << "]"<< " " << newLine;
+    std::vector<todoTxtNote> result;
+    while(std::getline(noteStream, line))
+        result.push_back(todoTxtNote(line));
+    noteStream.close();
+    return result;
+}
+
+void Note::list(bool show_completed) {
+    short i = 0;
+    std::vector<todoTxtNote> notes = getList();
+    for (auto note: notes) {
+        if (show_completed || !note.completed)
+            std::cout << '[' << i << ']' << ' ' << note.description << std::endl;
         i++;
     }
-    noteStream.close();
 }
 
 void Note::show(int n) {
-    noteStream.open(file, std::ios::in);
-    int i = 0;
-    while(std::getline(noteStream, line) && i < n) {
-        i++;
-    }
-    std::cout << line << std::endl;
-    noteStream.close();
-}
-
-std::vector<std::string> Note::getList() {
-    noteStream.open(file, std::ios::in);
-    std::vector<std::string> result;
-    while(std::getline(noteStream, line))
-        result.push_back(line);
-    noteStream.close();
-    return result;
+    std::cout << getList()[n].description << std::endl;
 }


### PR DESCRIPTION
This moves some code that might become common between noted and termNote to `note.cpp`, and adds some initial todo.txt support (parsing and hiding completed entries, changing completion state and dates, adding creation date in front of notes). This also improves logic of noted notifications. closes #16