### PR TITLE
Add unit tests for new todo.txt note functionality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,11 @@ include_directories(include)
 find_package(PkgConfig)
 pkg_check_modules(LIBNOTIFY QUIET libnotify)
 
+
+
+find_package(Catch2)
+
+
 set(COMMON "src/note.cpp")
 
 include_directories(${LIBNOTIFY_INCLUDE_DIRS})
@@ -16,9 +21,19 @@ set(CMAKE_CXX_FLAGS "-std=c++17")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 add_executable(termNote src/main.cpp ${COMMON})
 add_executable(noted src/noted.cpp ${COMMON})
+
+
+enable_testing()
+
+if (Catch2_FOUND)
+   add_executable(unitTest test/main.cpp ${COMMON})
+   target_link_libraries(unitTest stdc++fs Catch2::Catch2)
+   add_test(main bin/unitTest)
+endif ()
+
+
 target_link_libraries(${PROJECT_NAME} stdc++fs)
 target_link_libraries(noted stdc++fs ${LIBNOTIFY_LIBRARIES})
-
 
 install(TARGETS termNote noted DESTINATION bin)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,34 +6,34 @@ include_directories(include)
 find_package(PkgConfig)
 pkg_check_modules(LIBNOTIFY QUIET libnotify)
 
-
-
 find_package(Catch2)
-
 
 set(COMMON "src/note.cpp")
 
-include_directories(${LIBNOTIFY_INCLUDE_DIRS})
-link_directories(${LIBNOTIFY_LIBRARY_DIRS})
-ADD_DEFINITIONS(${LIBNOTIFY_CFLAGS})
-
+# Main executable (termNote)
 set(CMAKE_CXX_FLAGS "-std=c++17")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 add_executable(termNote src/main.cpp ${COMMON})
-add_executable(noted src/noted.cpp ${COMMON})
+target_link_libraries(${PROJECT_NAME} stdc++fs)
+install(TARGETS termNote DESTINATION bin)
 
 
+# noted
+if (LIBNOTIFY_FOUND)
+   include_directories(${LIBNOTIFY_INCLUDE_DIRS})
+   link_directories(${LIBNOTIFY_LIBRARY_DIRS})
+   add_definitions(${LIBNOTIFY_CFLAGS})
+   add_executable(noted src/noted.cpp ${COMMON})
+   target_link_libraries(noted stdc++fs ${LIBNOTIFY_LIBRARIES})
+   install(TARGETS noted DESTINATION bin)
+endif()
+
+# unit tests
 enable_testing()
-
 if (Catch2_FOUND)
    add_executable(unitTest test/main.cpp ${COMMON})
    target_link_libraries(unitTest stdc++fs Catch2::Catch2)
    add_test(main bin/unitTest)
 endif ()
 
-
-target_link_libraries(${PROJECT_NAME} stdc++fs)
-target_link_libraries(noted stdc++fs ${LIBNOTIFY_LIBRARIES})
-
-install(TARGETS termNote noted DESTINATION bin)
 

--- a/default.nix
+++ b/default.nix
@@ -6,6 +6,7 @@ stdenv.mkDerivation rec
 	src = ./.;
 	nativeBuildInputs = [ cmake pkgconfig ];
 	buildInputs = [ libnotify gdk_pixbuf pcre ];
-  doCheck = true;
-  checkPhase = builtins.readFile ./test.sh;
+    checkInputs = [ catch2 ];
+    doCheck = true;
+    checkPhase = builtins.readFile ./test.sh;
 }

--- a/result
+++ b/result
@@ -1,1 +1,1 @@
-/nix/store/xrdsfvs4yplkdy45rqfc1xx3lz1w6lkh-termNote
+/nix/store/3l3amiwg0crp5pbj47y9pwqz6x3p6yr4-termNote

--- a/result
+++ b/result
@@ -1,1 +1,1 @@
-/nix/store/5ahm89gn7xsfdgfbqdsg8w243phgdwli-termNote
+/nix/store/xrdsfvs4yplkdy45rqfc1xx3lz1w6lkh-termNote

--- a/test.sh
+++ b/test.sh
@@ -10,4 +10,5 @@ bin/termNote -a "This is a test note!"
 [[ $(bin/termNote -l) = *"This is a test note!"* ]] && echo OK || exit 1
 echo -n "Check that deleting notes works... "
 echo yes | bin/termNote -d 0 > /dev/null && echo OK || exit 1
-
+echo "Running unit tests..."
+make test

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,0 +1,41 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+#include <../include/note.hpp>
+
+TEST_CASE( "todo.txt format is parsed", "[todoTxtNote]" ) {
+    SECTION( "Full form is parsed" ) {
+        todoTxtNote full("x (A) 2019-01-01 2018-02-02 This is a note!");
+        REQUIRE(full.completed == true);
+        REQUIRE(full.priority == 'A');
+        REQUIRE(full.createdAt->tm_year == 2018 - 1900);
+        REQUIRE(full.createdAt->tm_mon == 1);
+        REQUIRE(full.createdAt->tm_mday == 2);
+        REQUIRE(full.completedAt->tm_year == 2019 - 1900);
+        REQUIRE(full.completedAt->tm_mon == 0);
+        REQUIRE(full.completedAt->tm_mday == 1);
+    }
+    SECTION( "Simple case is handled" ) {
+        todoTxtNote simple("This is a note!");
+        REQUIRE(simple.completed == false);
+        REQUIRE(simple.priority == 'z');
+        REQUIRE(simple.completedAt == nullptr);
+    }
+}
+
+
+TEST_CASE( "Notifications are parsed", "[todoTxtNote]" ) {
+    SECTION( "Empty note doesn't generate notifications" ) {
+        todoTxtNote mute("This note shouldn't generate any notifications");
+        REQUIRE(mute.getNotificationSpecs().size() == 0);
+    }
+    SECTION( "One exact specification is parsed" ) {
+        todoTxtNote one("This note should generate one notification at 02.10.2019 00:00");
+        REQUIRE(one.getNotificationSpecs().size() == 1);
+        REQUIRE(one.getNotificationSpecs()[0].size() == 2);
+    }
+    SECTION( "Multiple specifications are parsed" ) {
+        todoTxtNote two("This note should generate notifications at Jan Sun 18:00, 15.05.2020 15:00");
+        REQUIRE(two.getNotificationSpecs().size() == 2);
+        
+    }
+}


### PR DESCRIPTION
This PR adds unit tests as requested in #10 . It also refactors CMakeLists so that when libnotify is not found, `noted` is not built.