### PR TITLE
Refactor nix files and add distribution-independent binaries (nix bundles)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ cd termNote
 nix-build
 ```
 
+#### Building distribution-independent bundles
+```bash
+nix-build -A bundles.termNote
+nix-build -A bundles.noted
+```
+
+#### Building AppImages **(Currently broken, do not use!)**
+```bash
+nix-build -A AppImages.termNote
+nix-build -A AppImages.noted
+```
+
 ### Source
 
 ```bash
@@ -58,7 +70,7 @@ Run `./test.sh` in any POSIX-copmliant shell to run tests. This is done automati
 
 ## Usage
 ### `termNote` (The main utility)
-`termNote` is used to manipulate (`--add -a`, `--delete -d`, `--list -l`, `--show -s`) notes.
+`termNote` is used to manipulate (`--add -a`, `--delete -d`, `--list -l`, `--show -s`, `--complete -c`) notes.
 Entries are kept in `$XDG_DATA_HOME/termNote/notes` (or `$HOME/.termNote/notes` if you don't use XDG). Configuration is (going to) be kept in `$XDG_CONFIG_HOME/termNote/config`. Default option is `--list`.
 ### `noted` (The note daemon)
 `noted` is a notification daemon that uses `libnotify` to send you messages about due dates. It tries to guess what date and time you've meant (see #8 #15 for details). It forks by default (meaning it's safe to use in startup scripts), but you can make it stay in foreground by using `-f`. `-v` is mostly used for debugging.

--- a/README.md
+++ b/README.md
@@ -41,13 +41,16 @@ cd termNote
 nix-build
 ```
 
-#### Building distribution-independent bundles
+#### Building distribution-independent executables (nix bundles)
 ```bash
 nix-build -A bundles.termNote
 nix-build -A bundles.noted
 ```
 
-#### Building AppImages **(Currently broken, do not use!)**
+#### Building AppImages 
+
+**This is currently broken and it takes a long time to build. Build it only if you are ready to create a fix**
+
 ```bash
 nix-build -A AppImages.termNote
 nix-build -A AppImages.noted

--- a/default.nix
+++ b/default.nix
@@ -1,12 +1,41 @@
-with import <nixpkgs> {};
-
-stdenv.mkDerivation rec
-{
-	name = "termNote";
-	src = ./.;
-	nativeBuildInputs = [ cmake pkgconfig ];
-	buildInputs = [ libnotify gdk_pixbuf pcre ];
-    checkInputs = [ catch2 ];
-    doCheck = true;
-    checkPhase = builtins.readFile ./test.sh;
-}
+{ pkgs ? import <nixpkgs> {} }:
+let
+    termNote = pkgs.callPackage ./termNote.nix;
+    nix-bundle-src = builtins.fetchGit
+    {
+       url = "https://github.com/matthewbauer/nix-bundle";
+       rev = "113d8c6b426b0932a64c58c21cd065baad4c2314";
+    };
+    nix-bundle = (import ("${nix-bundle-src}/appimage-top.nix") {}) // (import "${nix-bundle-src}/default.nix" {});
+    AppImages =
+    {
+        termNote = nix-bundle.appimage
+        (nix-bundle.appdir
+        {
+            name = "termNote";
+            target = termNote { test = false; stripAll = true; desktop = true; notify = false; };
+        });
+        noted = nix-bundle.appimage
+        (nix-bundle.appdir
+        {
+            name = "noted";
+            target = termNote { test = false; stripAll = true; desktop = true; desktopTarget = "noted"; };
+        });
+    };
+    bundles =
+    {
+        termNote = nix-bundle.nix-bootstrap
+        {
+            extraTargets = [];
+            target = termNote { test = false; stripAll = true; notify = false; };
+            run = "/bin/termNote";
+        };
+        noted = nix-bundle.nix-bootstrap
+        {
+            extraTargets = [];
+            target = termNote { test = false; stripAll = true; };
+            run = "/bin/noted";
+        };
+    };
+in
+(termNote {}) // { inherit AppImages bundles; }

--- a/result
+++ b/result
@@ -1,1 +1,0 @@
-/nix/store/3l3amiwg0crp5pbj47y9pwqz6x3p6yr4-termNote

--- a/termNote.nix
+++ b/termNote.nix
@@ -1,0 +1,32 @@
+{ stdenv, cmake, pkgconfig, lib,
+  notify ? true, libnotify, gdk_pixbuf, pcre,
+  test ? true, catch2,
+  stripAll ? false,
+  desktop ? false, desktopTarget ? "termNote", makeDesktopItem }:
+stdenv.mkDerivation rec
+{
+  name = "termNote";
+  src = ./.;
+  nativeBuildInputs = [ cmake pkgconfig ];
+  buildInputs = lib.optionals notify [ libnotify gdk_pixbuf pcre ];
+  checkInputs = lib.optionals test [ catch2 ];
+  doCheck = test;
+  stripAllList = lib.optionals stripAll [ "bin" ];
+  checkPhase = builtins.readFile ./test.sh;
+  desktopItem = lib.optional desktop (makeDesktopItem
+  {
+    name = desktopTarget;
+    exec = "/bin/${desktopTarget}";
+    desktopName = desktopTarget;
+    terminal = "true";
+    categories = "Utility;";
+    icon = desktopTarget;
+  });
+  postInstall = lib.optional desktop ''
+  mkdir -p $out/share/icons
+  touch $out/share/icons/${desktopTarget}.png
+  mkdir -p $out/share/applications
+  substitute $desktopItem/share/applications/${desktopTarget}.desktop $out/share/applications/${desktopTarget}.desktop \
+     --subst-var out
+  '';
+}

--- a/termNote/notes
+++ b/termNote/notes
@@ -1,1 +1,0 @@
-(z) 2019-01-27 This is a test note! 


### PR DESCRIPTION
This PR changes the layout of nix files required to build the project and adds attributes that build nix bundles, which are distribution-independent executables. At this point, nix bundles are probably bigger and slower than they could be, but I've ran out of ideas on optimization.